### PR TITLE
added dash to arroyo-network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       - arroyo-network
 
 networks:
-  arroyo_network:
+  arroyo-network:
     name: arroyo-network
     driver: bridge


### PR DESCRIPTION
Changes made:

- Added a dash instead of underscore for ```arroyo-network``` in ```docker-compose.yml```.  Line #31
-  The docker daemon was complaining that a network called ```arroyo_network``` was created but never used. 